### PR TITLE
PoC: Add a component for displaying weekly matchups on recap posts

### DIFF
--- a/web/src/leagues/1048310882389983232/posts/2024/week-1.md
+++ b/web/src/leagues/1048310882389983232/posts/2024/week-1.md
@@ -3,6 +3,7 @@ title: Week 1 Recap
 date: '9/12/2024'
 published: true
 image: '/images/chungus/chungus-week-1.jpeg'
+week: 1
 ---
 
 Been a busy week! I’ve been wondering how I ever felt like I had time for writing these things and honestly was considering just not doing it this week or kinda phoning it in (which still might happen, I’m just starting out writing this thing). But the gods decided to punish me for even considering that annnddd I tested positive for Covid this morning. So I guess we might as well do this thing!

--- a/web/src/leagues/1048310882389983232/posts/2024/week-2.md
+++ b/web/src/leagues/1048310882389983232/posts/2024/week-2.md
@@ -3,6 +3,7 @@ title: Week 2 Recap
 date: '9/19/2024'
 published: true
 image: '/images/chungus/chungus-week-2.jpeg'
+week: 2
 ---
 
 Not much to say about Monday’s late night action, Danny really nailed it. I was indeed peacefully asleep and woke up to just wonderful news. I try to enjoy weeks like that because I also know all too well what it feels like to be on the other side, wanting to rip your hair out.

--- a/web/src/leagues/1048310882389983232/posts/2024/week-3.md
+++ b/web/src/leagues/1048310882389983232/posts/2024/week-3.md
@@ -3,6 +3,7 @@ title: Week 3 Recap
 date: '9/24/2024'
 published: true
 image: '/images/chungus/chungus-week-3-a.jpeg'
+week: 3
 ---
 
 <!-- Additional images should be placed inline like this -->

--- a/web/src/leagues/1048310882389983232/posts/2024/week-4.md
+++ b/web/src/leagues/1048310882389983232/posts/2024/week-4.md
@@ -3,6 +3,7 @@ title: Week 4 Recap
 date: '10/1/2024'
 published: true
 image: '/images/chungus/chungus-week-4.jpeg'
+week: 4
 ---
 
 ## 🏆 Standings

--- a/web/src/leagues/1048310882389983232/posts/2024/week-5.md
+++ b/web/src/leagues/1048310882389983232/posts/2024/week-5.md
@@ -3,6 +3,7 @@ title: Week 5 Recap
 date: '10/8/2024'
 published: true
 image: '/images/chungus/chungus-week-5.jpeg'
+week: 5
 ---
 
 Some incredibly close matchups this week were decided by Monday night and they resulted in some pretty big shifts in the standings. For the first time since sometime last year (idk when, Joe can look it up), someone other than Julian is in first place! We also got some trades to review, a new team name, and an exciting update to everyone’s favorite new section! And shoutout to Danny for running for 43 miles, winning the stupid race, and not getting rabdo (if you don’t know what it is don’t look it up)!

--- a/web/src/leagues/1048310882389983232/posts/2024/week-6.md
+++ b/web/src/leagues/1048310882389983232/posts/2024/week-6.md
@@ -3,6 +3,7 @@ title: Week 6 Recap
 date: '10/15/2024'
 published: true
 image: '/images/chungus/chungus-week-6.jpeg'
+week: 6
 ---
 
 ## Author's note

--- a/web/src/lib/components/Matchups.svelte
+++ b/web/src/lib/components/Matchups.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import type { MatchupGroups } from "$lib/sleeper-utils";
+
+	export let matchupGroups: MatchupGroups;
+</script>
+
+<table class="table rounded-sm">
+  <tbody>
+    {#each matchupGroups as [_, matchups]}
+      <tr class="text-gray-500">
+        <td class={matchups[0].points > matchups[1].points ? 'font-semibold bg-green-200' : 'bg-red-200'}>
+          <div class="flex flex-col gap-1 justify-center">
+            <div>{matchups[0].roster.name}</div>
+            <div>{matchups[0].points}</div>
+          </div>
+        </td>
+       <td class="bg-slate-100 text-center">vs</td>
+       <td class={matchups[1].points > matchups[0].points ? 'font-semibold bg-green-200' : 'bg-red-200'}>
+        <div class="flex flex-col gap-1 justify-center">
+          <div>{matchups[1].roster.name}</div>
+          <div>{matchups[1].points}</div>
+        </div>
+      </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/web/src/lib/models/Sleeper.model.ts
+++ b/web/src/lib/models/Sleeper.model.ts
@@ -31,6 +31,15 @@ export interface LeagueSettings {}
 
 export interface LeagueScoringSettings {}
 
+export interface Matchup {
+	starters: string[];
+	roster_id: number;
+	players: string[];
+	matchup_id: number;
+	points: number;
+	custom_points: number | null;
+}
+
 export interface Roster {
 	starters: string[];
 	settings: RosterSettings;

--- a/web/src/lib/sleeper-utils.ts
+++ b/web/src/lib/sleeper-utils.ts
@@ -1,4 +1,8 @@
-import type { Roster, User } from './models/Sleeper.model';
+import type { Matchup, Roster, User } from './models/Sleeper.model';
+
+export interface RosterWithName extends Roster {
+	name: string
+}
 
 export async function getStandings(
 	// The Svelte `fetch` function for better performance than window.fetch()
@@ -6,7 +10,7 @@ export async function getStandings(
 	league_id: string,
 	// TODO: allow getting standings as of a specific week once we have week by week point totals
 	week?: number
-): Promise<Roster[]> {
+): Promise<RosterWithName[]> {
 	const usersResponse = await fetch(`https://api.sleeper.app/v1/league/${league_id}/users`);
 	const users = (await usersResponse.json()) as User[];
 
@@ -26,7 +30,7 @@ export async function getStandings(
 			return {
 				...team,
 				name
-			};
+			} as RosterWithName;
 		})
 		.sort((a, b) => {
 			if (a.settings.wins === b.settings.wins) {
@@ -36,4 +40,41 @@ export async function getStandings(
 		});
 
 	return standings;
+}
+
+export interface MatchupWithRoster extends Matchup {
+	roster: RosterWithName
+}
+
+export type MatchupGroups = Map<number, MatchupWithRoster[]>
+
+export async function getMatchups(
+	// The Svelte `fetch` function for better performance than window.fetch()
+	fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+	league_id: string,
+	week: number,
+	rostersWithNames: RosterWithName[]
+): Promise<MatchupGroups> {
+	const matchupsResponse = await fetch(`https://api.sleeper.app/v1/league/${league_id}/matchups/${week}`);
+	const matchups = (await matchupsResponse.json()) as Matchup[];
+
+	const matchupGroups = new Map<number, MatchupWithRoster[]>()
+
+	for (const matchup of matchups) {
+		const roster = rostersWithNames.find((roster) => roster.roster_id === matchup.roster_id)
+
+		const matchGroup = matchupGroups.get(matchup.matchup_id)
+		const matchupWithRoster = {
+			...matchup,
+			roster
+		} as MatchupWithRoster
+
+		if (matchGroup) {
+			matchupGroups.set(matchup.matchup_id, matchGroup.concat(matchupWithRoster))
+		} else {
+			matchupGroups.set(matchup.matchup_id, [matchupWithRoster])
+		}
+	}
+
+	return matchupGroups
 }

--- a/web/src/routes/[league_id]/posts/[year]/[slug]/+page.svelte
+++ b/web/src/routes/[league_id]/posts/[year]/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { formatDate } from '$lib/utils';
+	import Matchups from '$lib/components/Matchups.svelte';
 
 	export let data;
 </script>
@@ -20,6 +21,11 @@
 			<img src={data.meta.image} alt="{data.meta.title} image" />
 		{/if}
 	</hgroup>
+
+	{#if data.matchupGroups}
+		<h2>Matchups</h2>
+		<Matchups matchupGroups={data.matchupGroups} />
+	{/if}
 
 	<div class="content">
 		<svelte:component this={data.content} />

--- a/web/src/routes/[league_id]/posts/[year]/[slug]/+page.ts
+++ b/web/src/routes/[league_id]/posts/[year]/[slug]/+page.ts
@@ -1,16 +1,29 @@
+import { getMatchups, getStandings, type MatchupGroups, type RosterWithName } from '$lib/sleeper-utils';
 import { error } from '@sveltejs/kit';
 
-export async function load({ params }) {
-	try {
-		const post = await import(
-			`../../../../../leagues/${params.league_id}/posts/${params.year}/${params.slug}.md`
-		);
+export async function load({ params: { league_id, year, slug} }) {
+	let post;
 
-		return {
-			content: post.default,
-			meta: post.metadata
-		};
-	} catch (e) {
-		error(404, `Could not find ${params.slug}`);
+	try {
+		post = await import(
+			`../../../../../leagues/${league_id}/posts/${year}/${slug}.md`
+		);
+	} catch {
+		error(404, `Could not find ${slug}`);
 	}
+
+	let matchupGroups: MatchupGroups | undefined;
+	let standings: RosterWithName[] | undefined
+
+	if (post.metadata.week) {
+		standings = await getStandings(fetch, league_id, post.metadata.week);
+		matchupGroups = await getMatchups(fetch, league_id, post.metadata.week, standings);
+	}
+
+	return {
+		content: post.default,
+		meta: post.metadata,
+		matchupGroups,
+		standings,
+	};
 }


### PR DESCRIPTION
I usually forget who was playing who by the time the recap comes around, so this adds a nice little table at the top of a post with `week` set in the frontmatter to set the stage a little.

Haven't looked into `mdsvex`, but maybe there's a way to set it up to work within the Markdown, rather than add it immediately to the front, if that's a non-starter (e.g. as a plugin or preprocessing step)

A look at the Tailwind-y table:

<img width="641" alt="Screenshot 2024-10-15 at 11 26 08 PM" src="https://github.com/user-attachments/assets/4b026b9c-95b2-42fa-b48c-a9851eaf7f35">
